### PR TITLE
fix for existing_summary bug

### DIFF
--- a/chapters/04-chat-memory.ipynb
+++ b/chapters/04-chat-memory.ipynb
@@ -1579,7 +1579,6 @@
         "            )\n",
         "        ])\n",
         "        # format the messages and invoke the LLM\n",
-        "        print(self.messages[0].content)\n",
         "        new_summary = self.llm.invoke(\n",
         "            summary_prompt.format_messages(\n",
         "                existing_summary = self.messages[0].content,\n",


### PR DESCRIPTION
new_summary = self.llm.invoke(
            summary_prompt.format_messages(
                existing_summary=self.messages.content,
                messages=[x.content for x in messages]
            )

changed to:

new_summary = self.llm.invoke(
            summary_prompt.format_messages(
                existing_summary = " ".join([x.content for x in self.messages]),
                messages=[x.content for x in messages]
            )

this is working on both notebook and colab

Error in RootListenersTracer.on_chain_end callback: AttributeError("'list' object has no attribute 'content'")

This error seems to be linked to the processing between prompt -> LLM unsure if this is a environmental bug 