### PR TITLE
Uses correct dall-e-model(dall-e-3)

### DIFF
--- a/chapters/01-intro.ipynb
+++ b/chapters/01-intro.ipynb
@@ -759,7 +759,7 @@
         "from langchain_core.runnables import RunnableLambda\n",
         "\n",
         "def generate_and_display_image(image_prompt):\n",
-        "    image_url = DallEAPIWrapper().run(image_prompt)\n",
+        "    image_url = DallEAPIWrapper(model = \"dall-e-3\").run(image_prompt)\n",
         "    image_data = io.imread(image_url)\n",
         "\n",
         "    # And update the display code to:\n",


### PR DESCRIPTION
This change resolves #22 by specifying the correct model of dall-e to use. Bad Request error was due to defaulting to using “dall-e-2", and in the OpenAI API call if we are using Dall-e-2, a “quality” parameter should not be sent otherwise an error is raised. The DallEAPIWrapper still sends in a quality parameter which results in an error. Specifying the model as "dall-e-3" resolved the issue.