### PR TITLE
fix: old messages trimming on 04-chat-memory.ipynb

### DIFF
--- a/chapters/04-chat-memory.ipynb
+++ b/chapters/04-chat-memory.ipynb
@@ -2198,7 +2198,7 @@
         "                f\">> Found {len(self.messages)} messages, dropping \"\n",
         "                f\"oldest {len(self.messages) - self.k} messages.\")\n",
         "            # pull out the oldest messages...\n",
-        "            old_messages = self.messages[:self.k]\n",
+        "            old_messages = self.messages[:-self.k]\n",
         "            # ...and keep only the most recent messages\n",
         "            self.messages = self.messages[-self.k:]\n",
         "        if old_messages is None:\n",


### PR DESCRIPTION
Issue:
`old_messages = self.messages[:self.k]`
`self.messages = self.messages[-self.k:]`

will unintentionally drop messages if the total number of messages is greater than 2 * k.

- old_messages = self.messages[:self.k] takes the first k messages (to be summarized).

- self.messages = self.messages[-self.k:] keeps only the last k messages.

- Any messages between the first k and the last k are dropped and not included in the summary or the buffer.

Example:
If you have 10 messages and k=3:

- old_messages = messages 0, 1, 2

- self.messages = messages 7, 8, 9

- Messages 3, 4, 5, 6 are lost.

Fix:
`old_messages = self.messages[:-self.k]`

